### PR TITLE
Access seodata field correctly in news

### DIFF
--- a/src/pages/news/[id].tsx
+++ b/src/pages/news/[id].tsx
@@ -152,7 +152,7 @@ const NewsItemDetails = ({
         setDesc(newsData?.description)
         setOtherNews(newsData?.otherNews)
         setBlurb(newsData?.blurb)
-        setSeoData({...seoData, ...newsData?.seoMetadata})
+        setSeoData({...seoData, ...newsData?.seoMetadata?.fields})
         const rawRichTextField = newsData?.description;
         const htmlString = documentToHtmlString(rawRichTextField);
         setRenderedHtml(htmlString);


### PR DESCRIPTION
Hey @shivam-ultivic please review and merge this one - for some reason needed to update how the seodata field was accessed here once it went to prod. Seems to work with this change.

On another note - I know the team recently started setting slugs for the news pages which doesn't seem to be fully supported in the code. I didn't do anything related to handling the news slugs vs ids in my previous changes so you may want to take a look at this. Seems like if slug is used the pages 404.